### PR TITLE
Added a provider property to the address class

### DIFF
--- a/src/Core/Address.cs
+++ b/src/Core/Address.cs
@@ -7,6 +7,7 @@ namespace GeoCoding
 	{
 		readonly string formattedAddress;
 		readonly Location coordinates;
+        readonly string provider;
 
 		public string FormattedAddress
 		{
@@ -18,7 +19,12 @@ namespace GeoCoding
 			get { return coordinates; }
 		}
 
-		public Address(string formattedAddress, Location coordinates)
+        public string Provider
+        {
+            get { return provider ?? ""; }
+        }
+
+		public Address(string formattedAddress, Location coordinates, string provider)
 		{
 			formattedAddress = (formattedAddress ?? "").Trim();
 
@@ -28,9 +34,13 @@ namespace GeoCoding
 			if (coordinates == null)
 				throw new ArgumentNullException("coordinates");
 
+            if (provider == null)
+                throw new ArgumentNullException("provider");
+
 			this.formattedAddress = formattedAddress;
 			this.coordinates = coordinates;
-		}
+            this.provider = provider;
+        }
 
 		public virtual Distance DistanceBetween(Address address)
 		{

--- a/src/Google/GoogleAddress.cs
+++ b/src/Google/GoogleAddress.cs
@@ -24,7 +24,7 @@ namespace GeoCoding.Google
 		}
 
 		public GoogleAddress(GoogleAddressType type, string formattedAddress, GoogleAddressComponent[] components, Location coordinates, bool isPartialMatch)
-			: base(formattedAddress, coordinates)
+			: base(formattedAddress, coordinates, "Google")
 		{
 			if (components == null)
 				throw new ArgumentNullException("components");

--- a/src/Microsoft/BingAddress.cs
+++ b/src/Microsoft/BingAddress.cs
@@ -40,7 +40,7 @@ namespace GeoCoding.Microsoft
 
 		public BingAddress(string formattedAddress, Location coordinates, string addressLine, string adminDistrict, string adminDistrict2,
 			string countryRegion, string locality, string postalCode, EntityType type, ConfidenceLevel confidence)
-			: base(formattedAddress, coordinates)
+			: base(formattedAddress, coordinates, "Bing")
 		{
 			this.addressLine = addressLine;
 			this.adminDistrict = adminDistrict;

--- a/src/Yahoo/YahooAddress.cs
+++ b/src/Yahoo/YahooAddress.cs
@@ -131,7 +131,7 @@ namespace GeoCoding
 		public YahooAddress(string formattedAddress, Location coordinates, string name, string house, string street,
 			string unit, string unitType, string neighborhood, string city, string county, string countyCode, string state,
 			string stateCode, string postalCode, string country, string countryCode, int quality)
-			: base(formattedAddress, coordinates)
+			: base(formattedAddress, coordinates, "Yahoo")
 		{
 			this.name = name;
 			this.house = house;


### PR DESCRIPTION
The provider property indicates which provider returned that specific address result. When multiple services are queried it can be useful to know which one provided the result being displayed.
