### PR TITLE
Removed types array length exception

### DIFF
--- a/src/Google/GoogleAddressComponent.cs
+++ b/src/Google/GoogleAddressComponent.cs
@@ -13,8 +13,6 @@ namespace Geocoding.Google
 			if (types == null)
 				throw new ArgumentNullException("types");
 
-			if (types.Length < 1)
-				throw new ArgumentException("Value cannot be empty.", "types");
 
 			this.Types = types;
 			this.LongName = longName;


### PR DESCRIPTION
There are results where the AddressComponent does not provide any "types", this is the case when you try to geocode the address "Rapidplatz 8953 Dietikon" (http://maps.googleapis.com/maps/api/geocode/json?address=Rapidplatz+8953+Dietikon&sensor=true).

The result looks like this:

"address_components" : [
            {
               "long_name" : "Rapidplatz",
               "short_name" : "Rapidplatz",
               "types" : []
            },
            {
               "long_name" : "Dietikon",
               "short_name" : "Dietikon",
               "types" : [ "locality", "political" ]
            },
            {
               "long_name" : "Zürich",
               "short_name" : "ZH",
               "types" : [ "administrative_area_level_1", "political" ]
            },
            {
               "long_name" : "Schweiz",
               "short_name" : "CH",
               "types" : [ "country", "political" ]
            },
            {
               "long_name" : "8953",
               "short_name" : "8953",
               "types" : [ "postal_code" ]
            }
         ],

As you can see the types array is empty.
