### PR TITLE
Check Proxy for null before assigning to the underlying WebRequest.Proxy

### DIFF
--- a/Google/GoogleGeocoder.cs
+++ b/Google/GoogleGeocoder.cs
@@ -313,7 +313,10 @@ namespace Geocoding.Google
 				url = BusinessKey.GenerateSignature(url);
 
 			var req = WebRequest.Create(url) as HttpWebRequest;
-			req.Proxy = Proxy;
+			if(this.Proxy != null) 
+			{
+				req.Proxy = Proxy;
+			}
 			req.Method = "GET";
 			return req;
 		}

--- a/Microsoft/BingMapsGeocoder.cs
+++ b/Microsoft/BingMapsGeocoder.cs
@@ -299,7 +299,10 @@ namespace Geocoding.Microsoft
 		private HttpWebRequest CreateRequest(string url)
 		{
 			var request = WebRequest.Create(url) as HttpWebRequest;
-			request.Proxy = Proxy;
+			if(this.Proxy != null) 
+			{
+				request.Proxy = this.Proxy;
+			}
 			return request;
 		}
 


### PR DESCRIPTION
Checks for null before assigning the proxy, respecting any app.config/web.config proxy settings.