### PR TITLE
GoogleAddressType added  SubLocalityLevel1,  SubLocalityLevel2, SubLocalityLevel3, SubLocalityLevel4, SubLocalityLevel5, PostalCodeSuffix

### DIFF
--- a/Geocoding.sln
+++ b/Geocoding.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{891021E5-7521-4F93-9946-B7B630DF3192}"
 	ProjectSection(SolutionItems) = preProject
@@ -28,6 +28,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft", "Microsoft\Microsoft.csproj", "{74BCB608-4674-452F-A50C-7EE61AC47EAF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MapQuest", "MapQuest\MapQuest.csproj", "{B37FC059-5E9E-4893-994A-64D835D2A54F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{9F62DA27-AF69-4288-9D69-C56614DE66A3}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Google/GoogleAddressType.cs
+++ b/Google/GoogleAddressType.cs
@@ -30,6 +30,12 @@ namespace Geocoding.Google
 		Floor,
 		Room,
 		PostalTown,
-		Establishment
+		Establishment,
+		SubLocalityLevel1,
+		SubLocalityLevel2,
+		SubLocalityLevel3,
+		SubLocalityLevel4,
+		SubLocalityLevel5,
+		PostalCodeSuffix
 	}
 }

--- a/Google/GoogleGeocoder.cs
+++ b/Google/GoogleGeocoder.cs
@@ -447,6 +447,12 @@ namespace Geocoding.Google
 				case "room": return GoogleAddressType.Room;
 				case "postal_town": return GoogleAddressType.PostalTown;
 				case "establishment": return GoogleAddressType.Establishment;
+				case "sublocality_level_1": return GoogleAddressType.SubLocalityLevel1;
+				case "sublocality_level_2": return GoogleAddressType.SubLocalityLevel2;
+				case "sublocality_level_3": return GoogleAddressType.SubLocalityLevel3;
+				case "sublocality_level_4": return GoogleAddressType.SubLocalityLevel4;
+				case "sublocality_level_5": return GoogleAddressType.SubLocalityLevel5;
+				case "postal_code_suffix": return GoogleAddressType.PostalCodeSuffix;
 
 				default: return GoogleAddressType.Unknown;
 			}


### PR DESCRIPTION
and GoogleGeocoder.GoogleAddressType EvaluateType(string type) added sublocality_level_1, sublocality_level_2, sublocality_level_3, sublocality_level_4, sublocality_level_5, postal_code_suffix