### PR TITLE
#42 Removed Expect header from mapquest

### DIFF
--- a/MapQuest/MapQuestGeocoder.cs
+++ b/MapQuest/MapQuestGeocoder.cs
@@ -170,7 +170,6 @@ namespace Geocoding.MapQuest
 			}
 			request.Method = f.RequestVerb;
 			request.ContentType = "application/" + f.InputFormat;
-			request.Expect = "application/" + f.OutputFormat;
 
 			if (Proxy != null)
 				request.Proxy = Proxy;


### PR DESCRIPTION
Mapquest API no longer works with the expect header.  Test with Fiddler
and through code.