### PR TITLE
Add Google component filters for administrative areas, postal codes and countries

### DIFF
--- a/Google/Google.csproj
+++ b/Google/Google.csproj
@@ -54,6 +54,8 @@
     <Compile Include="GoogleAddress.cs" />
     <Compile Include="GoogleAddressComponent.cs" />
     <Compile Include="GoogleAddressType.cs" />
+    <Compile Include="GoogleComponentFilter.cs" />
+    <Compile Include="GoogleComponentFilterType.cs" />
     <Compile Include="GoogleGeocoder.cs" />
     <Compile Include="GoogleGeocodingException.cs" />
     <Compile Include="GoogleLocationType.cs" />

--- a/Google/GoogleComponentFilter.cs
+++ b/Google/GoogleComponentFilter.cs
@@ -1,0 +1,12 @@
+﻿namespace Geocoding.Google
+{
+    public class GoogleComponentFilter
+    {
+        public string ComponentFilter { get; set; }
+
+        public GoogleComponentFilter(string component, string value)
+        {
+            ComponentFilter = string.Format("{0}:{1}", component, value);
+        }
+    }
+}

--- a/Google/GoogleComponentFilterType.cs
+++ b/Google/GoogleComponentFilterType.cs
@@ -1,0 +1,9 @@
+﻿namespace Geocoding.Google
+{
+    public struct GoogleComponentFilterType
+    {
+        public const string AdministrativeArea = "administrative_area";
+        public const string PostalCode = "postal_code";
+        public const string Country = "country";
+    }
+}

--- a/Google/GoogleGeocoder.cs
+++ b/Google/GoogleGeocoder.cs
@@ -65,6 +65,7 @@ namespace Geocoding.Google
 		public string Language { get; set; }
 		public string RegionBias { get; set; }
 		public Bounds BoundsBias { get; set; }
+		public IList<GoogleComponentFilter> ComponentFilters { get; set; }
 
 		public string ServiceUrl
 		{
@@ -108,6 +109,12 @@ namespace Geocoding.Google
 					builder.Append(",");
 					builder.Append(BoundsBias.NorthEast.Longitude.ToString(CultureInfo.InvariantCulture));
 				}
+				
+				if (ComponentFilters != null)
+                {
+                    builder.Append("&components=");
+                    builder.Append(string.Join("|", ComponentFilters.Select(x => x.ComponentFilter)));
+                }
 
 				return builder.ToString();
 			}


### PR DESCRIPTION
Added some functionality and tests for Google Component Filters. 

I've added this because we have a scenario here where we only want to geocode within the UK.

I didn't bother with Route, given that this allows you to geocode without an address, which is required in this implementation. 

I also haven't implemented Locality, as I couldn't find a use-case and didn't want to commit untested code.