### PR TITLE
Upgrade Geocoding.Net in Example.sln. Can't reproduce #45 and #48 after upgrade to Geocoding v3.5.

### DIFF
--- a/examples/Example.Web/Example.Web.csproj
+++ b/examples/Example.Web/Example.Web.csproj
@@ -47,8 +47,9 @@
     <Reference Include="Autofac.Integration.Mvc">
       <HintPath>..\packages\Autofac.Mvc4.3.1.0\lib\net40\Autofac.Integration.Mvc.dll</HintPath>
     </Reference>
-    <Reference Include="Geocoding">
-      <HintPath>..\packages\Geocoding.net.3.3.0\lib\net40\Geocoding.dll</HintPath>
+    <Reference Include="Geocoding, Version=3.5.0.0, Culture=neutral, PublicKeyToken=7c714700b88674c7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Geocoding.net.3.5.0\lib\net40\Geocoding.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/examples/Example.Web/Global.asax.cs
+++ b/examples/Example.Web/Global.asax.cs
@@ -7,6 +7,7 @@ using Geocoding;
 using Geocoding.Google;
 using Geocoding.Microsoft;
 using Geocoding.Yahoo;
+using Geocoding.MapQuest;
 
 namespace Example.Web
 {
@@ -42,6 +43,8 @@ namespace Example.Web
 			{
 				//ApiKey = "google-api-key-is-optional"
 			}).As<IGeocoder>();
+
+			builder.Register(c => new MapQuestGeocoder("mapquest-key") { UseOSM = true }).As<IGeocoder>();
 
 			return builder.Build();
 		}

--- a/examples/Example.Web/Web.config
+++ b/examples/Example.Web/Web.config
@@ -46,7 +46,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/examples/Example.Web/packages.config
+++ b/examples/Example.Web/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Autofac" version="3.1.5" targetFramework="net45" />
   <package id="Autofac.Mvc4" version="3.1.0" targetFramework="net45" />
-  <package id="Geocoding.net" version="3.3.0" targetFramework="net45" />
+  <package id="Geocoding.net" version="3.5.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />


### PR DESCRIPTION
It seems they are already fixed by commit ecc8cf61aab231c14d449c53b2cde99d58019e04
According to [this ](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.20) MapQuest can't handle Expect header values "application/json" and responded with status code 417.

As a result I would suggest to close #45 and #48.

P.S. I did some experiments with Expect property and could reproduce the problem for value "application/json" (or any other custom value), but MapQuest respond successfully if this header isn't set.