### PR TITLE
Added "includeNeighborhood" support to Bing Geocoder

### DIFF
--- a/src/Geocoding.Microsoft/BingAddress.cs
+++ b/src/Geocoding.Microsoft/BingAddress.cs
@@ -24,19 +24,19 @@
 		public string CountryRegion
 		{
 			get { return countryRegion ?? ""; }
-        }
+		}
 
-        public string Locality
-        {
-            get { return locality ?? ""; }
-        }
+		public string Locality
+		{
+			get { return locality ?? ""; }
+		}
 
-        public string Neighborhood
-        {
-            get { return neighborhood ?? ""; }
-        }
+		public string Neighborhood
+		{
+			get { return neighborhood ?? ""; }
+		}
 
-        public string PostalCode
+		public string PostalCode
 		{
 			get { return postalCode ?? ""; }
 		}
@@ -60,7 +60,7 @@
 			this.adminDistrict2 = adminDistrict2;
 			this.countryRegion = countryRegion;
 			this.locality = locality;
-            this.neighborhood = neighborhood;
+			this.neighborhood = neighborhood;
 			this.postalCode = postalCode;
 			this.type = type;
 			this.confidence = confidence;

--- a/src/Geocoding.Microsoft/BingAddress.cs
+++ b/src/Geocoding.Microsoft/BingAddress.cs
@@ -2,7 +2,7 @@
 {
 	public class BingAddress : Address
 	{
-		readonly string addressLine, adminDistrict, adminDistrict2, countryRegion, locality, postalCode;
+		readonly string addressLine, adminDistrict, adminDistrict2, countryRegion, locality, neighborhood, postalCode;
 		readonly EntityType type;
 		readonly ConfidenceLevel confidence;
 
@@ -24,14 +24,19 @@
 		public string CountryRegion
 		{
 			get { return countryRegion ?? ""; }
-		}
+        }
 
-		public string Locality
-		{
-			get { return locality ?? ""; }
-		}
+        public string Locality
+        {
+            get { return locality ?? ""; }
+        }
 
-		public string PostalCode
+        public string Neighborhood
+        {
+            get { return neighborhood ?? ""; }
+        }
+
+        public string PostalCode
 		{
 			get { return postalCode ?? ""; }
 		}
@@ -47,7 +52,7 @@
 		}
 
 		public BingAddress(string formattedAddress, Location coordinates, string addressLine, string adminDistrict, string adminDistrict2,
-			string countryRegion, string locality, string postalCode, EntityType type, ConfidenceLevel confidence)
+			string countryRegion, string locality, string neighborhood, string postalCode, EntityType type, ConfidenceLevel confidence)
 			: base(formattedAddress, coordinates, "Bing")
 		{
 			this.addressLine = addressLine;
@@ -55,6 +60,7 @@
 			this.adminDistrict2 = adminDistrict2;
 			this.countryRegion = countryRegion;
 			this.locality = locality;
+            this.neighborhood = neighborhood;
 			this.postalCode = postalCode;
 			this.type = type;
 			this.confidence = confidence;

--- a/src/Geocoding.Microsoft/BingMapsGeocoder.cs
+++ b/src/Geocoding.Microsoft/BingMapsGeocoder.cs
@@ -31,9 +31,9 @@ namespace Geocoding.Microsoft
 		public Location UserLocation { get; set; }
 		public Bounds UserMapView { get; set; }
 		public IPAddress UserIP { get; set; }
-        public bool IncludeNeighborhood { get; set; }
+		public bool IncludeNeighborhood { get; set; }
 
-        public BingMapsGeocoder(string bingKey)
+		public BingMapsGeocoder(string bingKey)
 		{
 			if (string.IsNullOrWhiteSpace(bingKey))
 				throw new ArgumentException("bingKey can not be null or empty");
@@ -86,11 +86,11 @@ namespace Geocoding.Microsoft
 			if (UserIP != null)
 				yield return new KeyValuePair<string, string>("userIp", UserIP.ToString());
 
-            if (IncludeNeighborhood)
-                yield return new KeyValuePair<string, string>("inclnb", IncludeNeighborhood ? "1" : "0");
-        }
+			if (IncludeNeighborhood)
+				yield return new KeyValuePair<string, string>("inclnb", IncludeNeighborhood ? "1" : "0");
+		}
 
-        private bool AppendGlobalParameters(StringBuilder parameters, bool first)
+		private bool AppendGlobalParameters(StringBuilder parameters, bool first)
 		{
 			var values = GetGlobalParameters().ToArray();
 
@@ -212,7 +212,7 @@ namespace Geocoding.Microsoft
 					location.Address.AdminDistrict2,
 					location.Address.CountryRegion,
 					location.Address.Locality,
-                    location.Address.Neighborhood,
+					location.Address.Neighborhood,
 					location.Address.PostalCode,
 					(EntityType)Enum.Parse(typeof(EntityType), location.EntityType),
 					EvaluateConfidence(location.Confidence)

--- a/src/Geocoding.Microsoft/BingMapsGeocoder.cs
+++ b/src/Geocoding.Microsoft/BingMapsGeocoder.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.Serialization.Json;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -30,8 +31,9 @@ namespace Geocoding.Microsoft
 		public Location UserLocation { get; set; }
 		public Bounds UserMapView { get; set; }
 		public IPAddress UserIP { get; set; }
+        public bool IncludeNeighborhood { get; set; }
 
-		public BingMapsGeocoder(string bingKey)
+        public BingMapsGeocoder(string bingKey)
 		{
 			if (string.IsNullOrWhiteSpace(bingKey))
 				throw new ArgumentException("bingKey can not be null or empty");
@@ -83,9 +85,12 @@ namespace Geocoding.Microsoft
 
 			if (UserIP != null)
 				yield return new KeyValuePair<string, string>("userIp", UserIP.ToString());
-		}
 
-		private bool AppendGlobalParameters(StringBuilder parameters, bool first)
+            if (IncludeNeighborhood)
+                yield return new KeyValuePair<string, string>("inclnb", IncludeNeighborhood ? "1" : "0");
+        }
+
+        private bool AppendGlobalParameters(StringBuilder parameters, bool first)
 		{
 			var values = GetGlobalParameters().ToArray();
 
@@ -207,6 +212,7 @@ namespace Geocoding.Microsoft
 					location.Address.AdminDistrict2,
 					location.Address.CountryRegion,
 					location.Address.Locality,
+                    location.Address.Neighborhood,
 					location.Address.PostalCode,
 					(EntityType)Enum.Parse(typeof(EntityType), location.EntityType),
 					EvaluateConfidence(location.Confidence)

--- a/src/Geocoding.Microsoft/Geocoding.Microsoft.csproj
+++ b/src/Geocoding.Microsoft/Geocoding.Microsoft.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.1" />
+    <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Geocoding.Microsoft/Json.cs
+++ b/src/Geocoding.Microsoft/Json.cs
@@ -15,9 +15,11 @@ namespace Geocoding.Microsoft.Json
 		public string CountryRegion { get; set; }
 		[DataMember(Name = "formattedAddress")]
 		public string FormattedAddress { get; set; }
-		[DataMember(Name = "locality")]
-		public string Locality { get; set; }
-		[DataMember(Name = "postalCode")]
+        [DataMember(Name = "locality")]
+        public string Locality { get; set; }
+        [DataMember(Name = "neighborhood")]
+        public string Neighborhood { get; set; }
+        [DataMember(Name = "postalCode")]
 		public string PostalCode { get; set; }
 	}
 	[DataContract]

--- a/src/Geocoding.Microsoft/Json.cs
+++ b/src/Geocoding.Microsoft/Json.cs
@@ -15,11 +15,11 @@ namespace Geocoding.Microsoft.Json
 		public string CountryRegion { get; set; }
 		[DataMember(Name = "formattedAddress")]
 		public string FormattedAddress { get; set; }
-        [DataMember(Name = "locality")]
-        public string Locality { get; set; }
-        [DataMember(Name = "neighborhood")]
-        public string Neighborhood { get; set; }
-        [DataMember(Name = "postalCode")]
+		[DataMember(Name = "locality")]
+		public string Locality { get; set; }
+		[DataMember(Name = "neighborhood")]
+		public string Neighborhood { get; set; }
+		[DataMember(Name = "postalCode")]
 		public string PostalCode { get; set; }
 	}
 	[DataContract]

--- a/test/Geocoding.Tests/BingMapsTest.cs
+++ b/test/Geocoding.Tests/BingMapsTest.cs
@@ -39,20 +39,29 @@ namespace Geocoding.Tests
 			geoCoder.UserLocation = new Location(userLatitude, userLongitude);
 			BingAddress[] addresses = (await geoCoder.GeocodeAsync(address)).ToArray();
 			Assert.Equal(country, addresses[0].CountryRegion);
-		}
+        }
 
-		[Theory]
-		[InlineData("Montreal", 45, -73, 46, -74, "Canada")]
-		[InlineData("Montreal", 43, 0, 44, 1, "France")]
-		[InlineData("Montreal", 46, -90, 47, -91, "United States")]
-		public async Task ApplyUserMapView(string address, double userLatitude1, double userLongitude1, double userLatitude2, double userLongitude2, string country)
-		{
-			geoCoder.UserMapView = new Bounds(userLatitude1, userLongitude1, userLatitude2, userLongitude2);
-			BingAddress[] addresses = (await geoCoder.GeocodeAsync(address)).ToArray();
-			Assert.Equal(country, addresses[0].CountryRegion);
-		}
+        [Theory]
+        [InlineData("Montreal", 45, -73, 46, -74, "Canada")]
+        [InlineData("Montreal", 43, 0, 44, 1, "France")]
+        [InlineData("Montreal", 46, -90, 47, -91, "United States")]
+        public async Task ApplyUserMapView(string address, double userLatitude1, double userLongitude1, double userLatitude2, double userLongitude2, string country)
+        {
+            geoCoder.UserMapView = new Bounds(userLatitude1, userLongitude1, userLatitude2, userLongitude2);
+            BingAddress[] addresses = (await geoCoder.GeocodeAsync(address)).ToArray();
+            Assert.Equal(country, addresses[0].CountryRegion);
+        }
 
-		[Fact]
+        [Theory]
+        [InlineData("24 sussex drive ottawa, ontario")]
+        public async Task ApplyIncludeNeighborhood(string address)
+        {
+            geoCoder.IncludeNeighborhood = true;
+            BingAddress[] addresses = (await geoCoder.GeocodeAsync(address)).ToArray();
+            Assert.NotNull(addresses[0].Neighborhood);
+        }
+
+        [Fact]
 		//https://github.com/chadly/Geocoding.net/issues/8
 		public async Task CanReverseGeocodeIssue8()
 		{

--- a/test/Geocoding.Tests/BingMapsTest.cs
+++ b/test/Geocoding.Tests/BingMapsTest.cs
@@ -39,29 +39,29 @@ namespace Geocoding.Tests
 			geoCoder.UserLocation = new Location(userLatitude, userLongitude);
 			BingAddress[] addresses = (await geoCoder.GeocodeAsync(address)).ToArray();
 			Assert.Equal(country, addresses[0].CountryRegion);
-        }
+		}
 
-        [Theory]
-        [InlineData("Montreal", 45, -73, 46, -74, "Canada")]
-        [InlineData("Montreal", 43, 0, 44, 1, "France")]
-        [InlineData("Montreal", 46, -90, 47, -91, "United States")]
-        public async Task ApplyUserMapView(string address, double userLatitude1, double userLongitude1, double userLatitude2, double userLongitude2, string country)
-        {
-            geoCoder.UserMapView = new Bounds(userLatitude1, userLongitude1, userLatitude2, userLongitude2);
-            BingAddress[] addresses = (await geoCoder.GeocodeAsync(address)).ToArray();
-            Assert.Equal(country, addresses[0].CountryRegion);
-        }
+		[Theory]
+		[InlineData("Montreal", 45, -73, 46, -74, "Canada")]
+		[InlineData("Montreal", 43, 0, 44, 1, "France")]
+		[InlineData("Montreal", 46, -90, 47, -91, "United States")]
+		public async Task ApplyUserMapView(string address, double userLatitude1, double userLongitude1, double userLatitude2, double userLongitude2, string country)
+		{
+			geoCoder.UserMapView = new Bounds(userLatitude1, userLongitude1, userLatitude2, userLongitude2);
+			BingAddress[] addresses = (await geoCoder.GeocodeAsync(address)).ToArray();
+			Assert.Equal(country, addresses[0].CountryRegion);
+		}
 
-        [Theory]
-        [InlineData("24 sussex drive ottawa, ontario")]
-        public async Task ApplyIncludeNeighborhood(string address)
-        {
-            geoCoder.IncludeNeighborhood = true;
-            BingAddress[] addresses = (await geoCoder.GeocodeAsync(address)).ToArray();
-            Assert.NotNull(addresses[0].Neighborhood);
-        }
+		[Theory]
+		[InlineData("24 sussex drive ottawa, ontario")]
+		public async Task ApplyIncludeNeighborhood(string address)
+		{
+			geoCoder.IncludeNeighborhood = true;
+			BingAddress[] addresses = (await geoCoder.GeocodeAsync(address)).ToArray();
+			Assert.NotNull(addresses[0].Neighborhood);
+		}
 
-        [Fact]
+		[Fact]
 		//https://github.com/chadly/Geocoding.net/issues/8
 		public async Task CanReverseGeocodeIssue8()
 		{


### PR DESCRIPTION
Added an extra global parameter to the Bing geocoder to set the includeNeighborhood flag on requests. Added a Neighbourhood field to the json response & BingAddress to hold the returned neighborhood field when the flag is set. Use this the same way as the other global parameters:
```
BingMapsGeocoder geoCoder = new BingMapsGeocoder(settings.BingMapsKey);
geoCoder.IncludeNeighborhood = true;
BingAddress[] addresses = (await geoCoder.GeocodeAsync(address)).ToArray();
string neighborhood = addresses[0].Neighborhood;
```