### PR TITLE
reverse geocode fix for double coords values

### DIFF
--- a/src/Geocoding.Google/GoogleGeocoder.cs
+++ b/src/Geocoding.Google/GoogleGeocoder.cs
@@ -154,7 +154,7 @@ namespace Geocoding.Google
 
 		private string BuildGeolocation(double latitude, double longitude)
 		{
-			return string.Format(CultureInfo.InvariantCulture, "{0},{1}", latitude, longitude);
+			return string.Format(CultureInfo.InvariantCulture, "{0:0.00000000},{1:0.00000000}", latitude, longitude);
 		}
 
 		private async Task<IEnumerable<GoogleAddress>> ProcessRequest(HttpRequestMessage request)


### PR DESCRIPTION
Same code as #74 without the merge conflicts.

Thanks for @alvillain for making the original fix!