### PR TITLE
Included multi-targeting to the full framework

### DIFF
--- a/src/Geocoding.Core/Geocoding.Core.csproj
+++ b/src/Geocoding.Core/Geocoding.Core.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Geocoding.net Core</AssemblyTitle>
     <VersionPrefix>4.0.0-beta1</VersionPrefix>
     <Authors>chadly</Authors>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <AssemblyName>Geocoding.Core</AssemblyName>
     <PackageId>Geocoding.Core</PackageId>
     <PackageTags>geocoding;geocode;geocoder;maps;address;validation;normalization;google-maps;bing-maps;yahoo-placefinder;mapquest</PackageTags>

--- a/src/Geocoding.Google/Geocoding.Google.csproj
+++ b/src/Geocoding.Google/Geocoding.Google.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Geocoding.net Google</AssemblyTitle>
     <VersionPrefix>4.0.0-beta1</VersionPrefix>
     <Authors>chadly</Authors>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <AssemblyName>Geocoding.Google</AssemblyName>
     <PackageId>Geocoding.Google</PackageId>
     <PackageTags>geocoding;geocode;geocoder;maps;address;validation;normalization;google-maps;bing-maps;yahoo-placefinder;mapquest</PackageTags>
@@ -21,9 +21,13 @@
     <ProjectReference Include="..\Geocoding.Core\Geocoding.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="System.Net.Http" Version="4.3.1" />
     <PackageReference Include="System.Xml.XPath" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net46'">
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/src/Geocoding.MapQuest/Geocoding.MapQuest.csproj
+++ b/src/Geocoding.MapQuest/Geocoding.MapQuest.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Geocoding.net MapQuest</AssemblyTitle>
     <VersionPrefix>4.0.0-beta1</VersionPrefix>
     <Authors>chadly</Authors>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <AssemblyName>Geocoding.MapQuest</AssemblyName>
     <PackageId>Geocoding.MapQuest</PackageId>
     <PackageTags>geocoding;geocode;geocoder;maps;address;validation;normalization;google-maps;bing-maps;yahoo-placefinder;mapquest</PackageTags>
@@ -21,7 +21,7 @@
     <ProjectReference Include="..\Geocoding.Core\Geocoding.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Geocoding.Microsoft/Geocoding.Microsoft.csproj
+++ b/src/Geocoding.Microsoft/Geocoding.Microsoft.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Geocoding.net Microsoft</AssemblyTitle>
     <VersionPrefix>4.0.0-beta1</VersionPrefix>
     <Authors>chadly</Authors>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <AssemblyName>Geocoding.Microsoft</AssemblyName>
     <PackageId>Geocoding.Microsoft</PackageId>
     <PackageTags>geocoding;geocode;geocoder;maps;address;validation;normalization;google-maps;bing-maps;yahoo-placefinder;mapquest</PackageTags>
@@ -23,8 +23,15 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="System.Net.Http" Version="4.3.1" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net46'">
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/src/Geocoding.Yahoo/Geocoding.Yahoo.csproj
+++ b/src/Geocoding.Yahoo/Geocoding.Yahoo.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Geocoding.net Yahoo</AssemblyTitle>
     <VersionPrefix>4.0.0-beta1</VersionPrefix>
     <Authors>chadly</Authors>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
     <AssemblyName>Geocoding.Yahoo</AssemblyName>
     <PackageId>Geocoding.Yahoo</PackageId>
     <PackageTags>geocoding;geocode;geocoder;maps;address;validation;normalization;google-maps;bing-maps;yahoo-placefinder;mapquest</PackageTags>
@@ -21,7 +21,7 @@
     <ProjectReference Include="..\Geocoding.Core\Geocoding.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
     <PackageReference Include="System.Xml.XPath" Version="4.3.0" />


### PR DESCRIPTION
Hi there,

I have included multi targeting to include the full .NET Framework. When you install the package into a full framework project, it will nevertheless install all dependencies if the package targets only .NET Standard. For example I will get the System.Http nuget package as a reference, despite my full framework already providing that as a normal, non-nuget reference. So now I have two (if I include other packages sometimes even three) versions of Http in my project.

I multi-targeted the packages to .NET 4.6 because that is listed as the equivalent of .NET Standard 1.3 over at https://github.com/dotnet/standard/blob/master/docs/versions.md

So now it will work correctly in *both*, .NET Standard *and* the full .NET Framework.

ciao
nvoigt
