### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.cs]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+tab_width = 4
+charset = utf-8-bom


### PR DESCRIPTION
I've added this to prevent my Visual Studio from messing up the indentation.

There are some .NET-specific EditorConfig rules for [language features](docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference?view=vs-2017) and [naming conventions](https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-naming-conventions?view=vs-2017) but for now I've decided against adding those as there are some inconsistencies in the code base and I wasn't sure which values are preferred.