### PR TITLE
Fix async tests

### DIFF
--- a/test/Geocoding.Tests/AsyncGeocoderTest.cs
+++ b/test/Geocoding.Tests/AsyncGeocoderTest.cs
@@ -72,7 +72,7 @@ namespace Geocoding.Tests
 		public async Task CanReverseGeocodeAsync()
 		{
 			var addresses = await asyncGeocoder.ReverseGeocodeAsync(38.8976777, -77.036517);
-			addresses.First().AssertWhiteHouseArea();
+			addresses.First().AssertWhiteHouse();
 		}
 	}
 }

--- a/test/Geocoding.Tests/AsyncGeocoderTest.cs
+++ b/test/Geocoding.Tests/AsyncGeocoderTest.cs
@@ -19,23 +19,17 @@ namespace Geocoding.Tests
 		protected abstract IGeocoder CreateAsyncGeocoder();
 
 		[Fact]
-		public void CanGeocodeAddress()
+		public async Task CanGeocodeAddress()
 		{
-			asyncGeocoder.GeocodeAsync("1600 pennsylvania ave washington dc").ContinueWith(task =>
-			{
-				Address[] addresses = task.Result.ToArray();
-				addresses[0].AssertWhiteHouse();
-			});
+			var addresses = await asyncGeocoder.GeocodeAsync("1600 pennsylvania ave washington dc");
+			addresses.First().AssertWhiteHouse();
 		}
 
 		[Fact]
-		public void CanGeocodeNormalizedAddress()
+		public async Task CanGeocodeNormalizedAddress()
 		{
-			asyncGeocoder.GeocodeAsync("1600 pennsylvania ave", "washington", "dc", null, null).ContinueWith(task =>
-			{
-				Address[] addresses = task.Result.ToArray();
-				addresses[0].AssertWhiteHouse();
-			});
+			var addresses = await asyncGeocoder.GeocodeAsync("1600 pennsylvania ave", "washington", "dc", null, null);
+			addresses.First().AssertWhiteHouse();
 		}
 
 		[Theory]
@@ -45,9 +39,8 @@ namespace Geocoding.Tests
 		{
 			//Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(cultureName);
 
-		    var result = await asyncGeocoder.GeocodeAsync("24 sussex drive ottawa, ontario");
-			Address[] addresses = result.ToArray();
-			addresses[0].AssertCanadianPrimeMinister();
+		    var addresses = await asyncGeocoder.GeocodeAsync("24 sussex drive ottawa, ontario");
+			addresses.First().AssertCanadianPrimeMinister();
 		}
 
 		[Theory]
@@ -57,41 +50,29 @@ namespace Geocoding.Tests
 		{
 			//Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(cultureName);
 
-		    var result = await asyncGeocoder.ReverseGeocodeAsync(38.8976777, -77.036517);
-			Address[] addresses = result.ToArray();
-			addresses[0].AssertWhiteHouseArea();
+		    var addresses = await asyncGeocoder.ReverseGeocodeAsync(38.8976777, -77.036517);
+			addresses.First().AssertWhiteHouseArea();
 		}
 
 		[Fact]
-		public void ShouldNotBlowUpOnBadAddress()
+		public async Task ShouldNotBlowUpOnBadAddress()
 		{
-			asyncGeocoder.GeocodeAsync("sdlkf;jasl;kjfldksjfasldf").ContinueWith(task =>
-			{
-				var addresses = task.Result;
-				Assert.Empty(addresses);
-			});
+			var addresses = await asyncGeocoder.GeocodeAsync("sdlkf;jasl;kjfldksjfasldf");
+			Assert.Empty(addresses);
 		}
 
 		[Fact]
-		public void CanGeocodeWithSpecialCharacters()
+		public async Task CanGeocodeWithSpecialCharacters()
 		{
-			asyncGeocoder.GeocodeAsync("Fried St & 2nd St, Gretna, LA 70053").ContinueWith(task =>
-			{
-				var addresses = task.Result;
-
-				//asserting no exceptions are thrown and that we get something
-				Assert.NotEmpty(addresses);
-			});
+			var addresses = await asyncGeocoder.GeocodeAsync("Fried St & 2nd St, Gretna, LA 70053");
+			Assert.NotEmpty(addresses);
 		}
 
 		[Fact]
-		public void CanReverseGeocodeAsync()
+		public async Task CanReverseGeocodeAsync()
 		{
-			asyncGeocoder.ReverseGeocodeAsync(38.8976777, -77.036517).ContinueWith(task =>
-			{
-				Address[] addresses = task.Result.ToArray();
-				addresses[0].AssertWhiteHouseArea();
-			});
+			var addresses = await asyncGeocoder.ReverseGeocodeAsync(38.8976777, -77.036517);
+			addresses.First().AssertWhiteHouseArea();
 		}
 	}
 }

--- a/test/Geocoding.Tests/AsyncGeocoderTest.cs
+++ b/test/Geocoding.Tests/AsyncGeocoderTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -11,7 +12,7 @@ namespace Geocoding.Tests
 
         public AsyncGeocoderTest()
 		{
-			//Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-us");
+			CultureInfo.CurrentCulture = new CultureInfo("en-us");
 
 			asyncGeocoder = CreateAsyncGeocoder();
 		}
@@ -37,7 +38,7 @@ namespace Geocoding.Tests
 		[InlineData("cs-CZ")]
 		public async Task CanGeocodeAddressUnderDifferentCultures(string cultureName)
 		{
-			//Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(cultureName);
+			CultureInfo.CurrentCulture = new CultureInfo(cultureName);
 
 		    var addresses = await asyncGeocoder.GeocodeAsync("24 sussex drive ottawa, ontario");
 			addresses.First().AssertCanadianPrimeMinister();
@@ -48,7 +49,7 @@ namespace Geocoding.Tests
 		[InlineData("cs-CZ")]
 		public async Task CanReverseGeocodeAddressUnderDifferentCultures(string cultureName)
 		{
-			//Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(cultureName);
+			CultureInfo.CurrentCulture = new CultureInfo(cultureName);
 
 		    var addresses = await asyncGeocoder.ReverseGeocodeAsync(38.8976777, -77.036517);
 			addresses.First().AssertWhiteHouseArea();


### PR DESCRIPTION
This partially fixes #113. I didn't fix anything that relates to the data itself (such as unexpected location types) but all the systematic errors in `AsyncGeocoderTest` should be gone.