### PR TITLE
Google API Key is not optional anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Install-Package Geocoding.Here
 ### Simple Example
 
 ```csharp
-IGeocoder geocoder = new GoogleGeocoder() { ApiKey = "this-is-my-optional-google-api-key" };
+IGeocoder geocoder = new GoogleGeocoder() { ApiKey = "this-is-my-google-api-key" };
 IEnumerable<Address> addresses = await geocoder.GeocodeAsync("1600 pennsylvania ave washington dc");
 Console.WriteLine("Formatted: " + addresses.First().FormattedAddress); //Formatted: 1600 Pennsylvania Ave SE, Washington, DC 20003, USA
 Console.WriteLine("Coordinates: " + addresses.First().Coordinates.Latitude + ", " + addresses.First().Coordinates.Longitude); //Coordinates: 38.8791981, -76.9818437


### PR DESCRIPTION
As referring to following issue, updated README
https://github.com/chadly/Geocoding.net/issues/144